### PR TITLE
feat: consolidate workflow notebook

### DIFF
--- a/VQuintana/functions/main_utils.py
+++ b/VQuintana/functions/main_utils.py
@@ -1,0 +1,253 @@
+"""Utility functions for the combined hyporheic model workflow.
+
+This module centralises reusable helpers that were previously spread
+across multiple notebooks.  Functions here intentionally avoid
+side-effects so they can be imported and unit tested independently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePath
+from types import SimpleNamespace
+from typing import Any, Sequence, Tuple
+
+import numpy as np
+import flopy
+from scipy.interpolate import griddata
+
+try:
+    from modflow_devtools.misc import timed  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    def timed(func):  # type: ignore
+        return func
+
+
+# ---------------------------------------------------------------------
+# General helper functions
+# ---------------------------------------------------------------------
+
+def interpolate_na(terrain: np.ma.MaskedArray) -> np.ndarray:
+    """Interpolate missing values in a masked terrain array.
+
+    Parameters
+    ----------
+    terrain : np.ma.MaskedArray
+        Masked array of terrain values where ``terrain.mask`` identifies
+        cells requiring interpolation.
+    """
+    # Get coordinates of valid/invalid cells
+    valid_mask = ~terrain.mask
+    valid_coords = np.array(np.nonzero(valid_mask)).T
+    valid_values = terrain[valid_mask]
+
+    invalid_mask = terrain.mask
+    invalid_coords = np.array(np.nonzero(invalid_mask)).T
+
+    # Interpolate using nearest-neighbour
+    interpolated_values = griddata(
+        valid_coords, valid_values, invalid_coords, method="nearest"
+    )
+    filled = terrain.copy()
+    filled[invalid_mask] = interpolated_values
+    return filled
+
+
+def calculate_gw_elevation(boundary_cells, top_elevation, offset):
+    """Calculate groundwater elevation for a set of boundary cells."""
+    gw_elevation_min: list[float] = []
+    for cell in boundary_cells:
+        layer, row, col = cell
+        gw_elevation = top_elevation + offset
+        gw_elevation_min.append([layer, row, col, gw_elevation])
+    return gw_elevation_min
+
+
+def interpolate_gw_elevation_first_layer_only(
+    first_layer_cells: list[tuple[int, int, int]],
+    head_first: float,
+    head_last: float,
+) -> list[float]:
+    """Linearly interpolate groundwater elevation across boundary cells."""
+    n_cells = len(first_layer_cells)
+    interpolated_heads: list[float] = []
+    for idx, cell in enumerate(first_layer_cells):
+        frac = idx / max(n_cells - 1, 1)
+        head = head_first + frac * (head_last - head_first)
+        interpolated_heads.append([*cell, head])
+    return interpolated_heads
+
+
+# ---------------------------------------------------------------------
+# Model construction and execution
+# ---------------------------------------------------------------------
+
+def build_gwf_model(
+    cfg: Any,
+    chd_data: Sequence[Sequence[float]],
+    idomain: np.ndarray,
+) -> Tuple[flopy.mf6.MFSimulation, flopy.mf6.ModflowGwf]:
+    """Construct a stand-alone MODFLOW 6 groundwater-flow model.
+
+    This is a lightly adapted version of the implementation originally
+    contained in the `run_models.ipynb` notebook.  The function assembles
+    a MODFLOW 6 simulation using configuration values provided in
+    ``cfg`` along with constant-head (CHD) data and an ``idomain`` mask.
+    """
+    if idomain.shape != (cfg.nlay, cfg.nrow, cfg.ncol):  # type: ignore[attr-defined]
+        raise ValueError("`idomain` dimensions don’t match cfg grid.")
+
+    sim = flopy.mf6.MFSimulation(
+        sim_name=cfg.sim_name,
+        exe_name=str(cfg.md6_exe_path),
+        sim_ws=str(cfg.gwf_ws),
+    )
+
+    flopy.mf6.ModflowTdis(
+        sim,
+        time_units=cfg.time_units.upper(),
+        nper=cfg.nper,
+        perioddata=[(cfg.perlen, cfg.nstp, cfg.tsmult)],
+    )
+
+    gwf = flopy.mf6.ModflowGwf(
+        sim,
+        modelname=cfg.gwf_name,
+        save_flows=True,
+    )
+
+    flopy.mf6.ModflowGwfdis(
+        gwf,
+        nlay=cfg.nlay,
+        nrow=cfg.nrow,
+        ncol=cfg.ncol,
+        delr=cfg.cell_size_x,
+        delc=cfg.cell_size_y,
+        top=cfg.tops[0],
+        botm=cfg.botm,
+        idomain=idomain,
+        xorigin=cfg.xmin,
+        yorigin=cfg.ymin,
+    )
+
+    gwf.modelgrid.crs = cfg.raster_crs
+    gwf.modelgrid.set_coord_info(cfg.xmin, cfg.ymin, crs=cfg.raster_crs)
+
+    strt = np.full((cfg.nlay, cfg.nrow, cfg.ncol), cfg.bed_elevation, dtype=float)
+    flopy.mf6.ModflowGwfic(gwf, strt=strt)
+
+    flopy.mf6.ModflowGwfnpf(
+        gwf,
+        icelltype=2,
+        k=cfg.kh,
+        k33=cfg.kv,
+        save_flows=True,
+        save_saturation=True,
+        save_specific_discharge=True,
+    )
+
+    if chd_data:
+        flopy.mf6.ModflowGwfchd(
+            gwf,
+            maxbound=len(chd_data),
+            stress_period_data={0: chd_data},
+            save_flows=True,
+        )
+
+    flopy.mf6.ModflowGwfoc(
+        gwf,
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+        head_filerecord=[cfg.headfile],
+        budget_filerecord=[cfg.budgetfile],
+        printrecord=[("HEAD", "LAST")],
+    )
+
+    flopy.mf6.ModflowIms(
+        sim,
+        print_option="SUMMARY",
+        outer_dvclose=1e-4,
+        outer_maximum=200,
+        inner_maximum=500,
+        inner_dvclose=1e-4,
+        rcloserecord=1e-4,
+        linear_acceleration="BICGSTAB",
+        relaxation_factor=0.97,
+    )
+
+    return sim, gwf
+
+
+def build_particle_models(
+    sim_name: str,
+    gwf: flopy.mf6.ModflowGwf,
+    river_cells: list[tuple[int, int, int]],
+    *,
+    mp7_ws: Path | str | None = None,
+    exe_path: Path | str | None = None,
+):
+    """Create forward and backward MODPATH 7 models."""
+    from flopy.modpath import Modpath7, ParticleData, ParticleGroup
+
+    if mp7_ws is None:
+        mp7_ws = Path(gwf.simulation.sim_path).parent / "mp7_workspace"
+    mp7_ws = Path(mp7_ws).absolute()
+    mp7_ws.mkdir(exist_ok=True)
+
+    if exe_path is None:
+        exe_path = "mp7"
+
+    def _make(direction: str):
+        mp = Modpath7.create_mp7(
+            modelname=f"{sim_name}_mp_{direction}",
+            trackdir=direction,
+            flowmodel=gwf,
+            model_ws=mp7_ws,
+            exe_name=str(exe_path),
+        )
+        partlocs = [(k, i, j) for (k, i, j, *_) in river_cells]
+        particle_data = ParticleData(partlocs, structured=True, drape=0)
+        pg = ParticleGroup(particledata=particle_data)
+        mpsim = mp.get_package("MPSIM")
+        mpsim.particlegroups.clear()
+        mpsim.particlegroups.append(pg)
+        return mp
+
+    return _make("forward"), _make("backward")
+
+
+def write_models(*sims, silent: bool = False) -> None:
+    """Write MODFLOW or MODPATH models to disk."""
+    for sim in sims:
+        if isinstance(sim, flopy.mf6.MFSimulation):
+            sim.write_simulation(silent=silent)
+        else:
+            sim.write_input()
+
+
+@timed
+def run_models(*sims, silent: bool = False) -> None:
+    """Run one or more MODFLOW/MODPATH simulations."""
+    for sim in sims:
+        if isinstance(sim, flopy.mf6.MFSimulation):
+            print(f"Running simulation: {sim.name}")
+            success, buff = sim.run_simulation(silent=silent, report=True)
+        else:
+            print(f"Running model: {sim.name}")
+            success, buff = sim.run_model(silent=silent, report=True)
+        if not success:
+            raise RuntimeError(f"Simulation {sim.name} failed: {buff}")
+
+
+# Placeholder for the extensive post-processing logic originally present
+# in ``run_models.ipynb``.  The detailed implementation has been omitted
+# here for brevity but can be reintroduced as required.
+def process_and_export_modpath7_results(*args, **kwargs):  # pragma: no cover
+    """Process MODPATH 7 results and export spatial datasets.
+
+    The full implementation is available in the original notebook.  This
+    placeholder allows the main workflow notebook to import the symbol
+    without executing heavy post-processing when not needed.
+    """
+    raise NotImplementedError(
+        "process_and_export_modpath7_results is not implemented in this "
+        "repository snapshot."
+    )

--- a/VQuintana/notebooks/Hyporheic_FloPy_Main.ipynb
+++ b/VQuintana/notebooks/Hyporheic_FloPy_Main.ipynb
@@ -1,0 +1,108 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "# Hyporheic FloPy Main Workflow\nCombines preprocessing, model setup, execution, and post-processing into a single notebook."
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Preprocessing"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "from pathlib import Path\nfrom types import SimpleNamespace\nimport numpy as np\nimport pandas as pd\nimport geopandas as gpd\n\nfrom VQuintana.functions import raster_utils as ru\nfrom VQuintana.functions import model_utils as mu\nfrom VQuintana.functions import main_utils as mutils\n\n# User-updatable paths\nproject_dir = Path(\"VQuintana/CH00365\")\ndata_dir = Path(\"VQuintana/notebooks\")\noutput_dir = data_dir / \"Hyporheic_output\"\n\nterrain_raster = data_dir / \"reprojected_terrain_raster.tif\"\nwater_surface_raster = data_dir / \"reprojected_water_surface_elevation_raster.tif\"\ndomain_shp = project_dir / \"GWDomain.shp\"\nleft_boundary_shp = project_dir / \"L_FPL.shp\"\nright_boundary_shp = project_dir / \"R_FPL.shp\"\nriver_cells_csv = data_dir / \"river_cells.csv\"\n\n# Load rasters\nterrain, transform, crs, nodata, bounds_box = ru.load_raster(terrain_raster)\nterrain = ru.interpolate_na(ru.mask_nodata(terrain, nodata))\nwater_surface, _, _, _, _ = ru.load_raster(water_surface_raster)\nwater_surface = ru.interpolate_na(ru.mask_nodata(water_surface, nodata))\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Initialization"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "cfg = SimpleNamespace(\n    sim_name=\"hyporheic_sim\",\n    gwf_name=\"gwf_model\",\n    gwf_ws=output_dir,\n    mp7_ws=output_dir / \"mp7\",\n    md6_exe_path=\"mf6\",\n    mp7_exe_path=\"mp7\",\n    cell_size_x=100.0,\n    cell_size_y=100.0,\n    nlay=1,\n    nper=1,\n    nstp=1,\n    perlen=1.0,\n    tsmult=1.0,\n    time_units=\"DAYS\",\n    bed_elevation=float(np.nanmin(terrain)),\n    kh=1.0,\n    kv=1.0,\n    headfile=\"head.hds\",\n    budgetfile=\"budget.cbc\",\n)\n\nxmin, ymin, xmax, ymax = ru.raster_extent(transform, terrain.shape[1], terrain.shape[0])\ncfg.xmin, cfg.ymin, cfg.xmax, cfg.ymax = xmin, ymin, xmax, ymax\nwidth_ft = xmax - xmin\nheight_ft = ymax - ymin\ncfg.ncol, cfg.nrow = ru.grid_dimensions(width_ft, height_ft, cfg.cell_size_x, cfg.cell_size_y)\ngrid_x, grid_y = ru.generate_grid_centres(cfg.ncol, cfg.nrow, cfg.cell_size_x, cfg.cell_size_y, xmin, ymin)\ngrid_points = ru.grid_to_geodataframe(grid_x, grid_y, crs)\n\ncfg.tops = [terrain]\ncfg.botm = [terrain - cfg.bed_elevation]\ncfg.raster_crs = crs\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Model Domain"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "domain_gdf = gpd.read_file(domain_shp)\ngrid_polys = mu.build_grid_polygons(grid_x, grid_y, cfg.cell_size_x, cfg.cell_size_y, crs)\nidomain = mu.idomain_from_domain(grid_polys, domain_gdf, cfg.nlay, cfg.nrow, cfg.ncol)\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Define Boundary"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "left_boundary = gpd.read_file(left_boundary_shp)\nright_boundary = gpd.read_file(right_boundary_shp)\nupstream, downstream = mu.make_up_down_stream(left_boundary, right_boundary, crs)\nriver_df = pd.read_csv(river_cells_csv)\nriver_cells = [tuple(map(int, r)) for r in river_df[['k','i','j']].values]\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Boundary Conditions"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "boundary_cells = [(0, i, j) for (_, i, j) in river_cells]\nchd_data = mutils.interpolate_gw_elevation_first_layer_only(\n    boundary_cells,\n    head_first=float(np.min(water_surface)),\n    head_last=float(np.max(water_surface)),\n)\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Run Models"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "sim, gwf = mutils.build_gwf_model(cfg, chd_data, idomain)\nmp_fwd, mp_bwd = mutils.build_particle_models(cfg.sim_name, gwf, river_cells, mp7_ws=cfg.mp7_ws, exe_path=cfg.mp7_exe_path)\nmutils.write_models(sim, mp_fwd, mp_bwd)\nmutils.run_models(sim, mp_fwd, mp_bwd)\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Particle Results"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "# Placeholder for particle tracking results\n# mutils.process_and_export_modpath7_results(mp_fwd, mp_bwd)\n"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "## Tech Note Figures"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "# Placeholder for figure generation\n"
+    }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- expand `Hyporheic_FloPy_Main` notebook to run preprocessing, domain setup, boundary conditions and model execution using helper utilities
- keep placeholders for particle results and technical note figures

## Testing
- `python -m py_compile VQuintana/functions/main_utils.py`
- `pip install nbformat` *(fails: Could not find a version that satisfies the requirement nbformat)*

------
https://chatgpt.com/codex/tasks/task_e_68aa730e9a8883278170ce5bb65913aa